### PR TITLE
chore: fix dns pkg testbench

### DIFF
--- a/lib/dns/dns_test.go
+++ b/lib/dns/dns_test.go
@@ -1,20 +1,47 @@
 package dns
 
-import "testing"
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+)
 
 func TestDirectDNS(t *testing.T) {
-	RoaFinder = "223.5.5.5:53"
 	testcases := []string{
 		"www.baidu.com",
+		"www.hdu.edu.cn",
 	}
+	RoaFinder = "223.5.5.5:53"
+	t.Logf("Using %s as RoaFinder", RoaFinder)
+
+	// start of client init
+	ResolveUDPAddr = net.ResolveUDPAddr
+	if _, err := netip.ParseAddr(RoaFinder); err == nil {
+		RoaFinder = net.JoinHostPort(RoaFinder, "53")
+	}
+	DefaultClient = &dns.Client{
+		Dialer: &net.Dialer{
+			Resolver: &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					return net.Dial(network, RoaFinder)
+				},
+			},
+		},
+	}
+	// end of client init
+
 	for _, testcase := range testcases {
+		t.Logf("Attempting to resolve %s", testcase)
 		ip, err := directDNS(testcase)
 		if err != nil {
 			t.Errorf("directDNS error:%v", err)
 			return
 		}
-		t.Log(ip)
-
+		t.Logf("Resolved IP is %s", ip)
 	}
 }
 


### PR DESCRIPTION
The current application requires an initialization of dns.Client before use. 
To reach this, setup code was copied and simplified from Init function in dns package to avoid redundant dependency of conf package.