### PR TITLE
fix(log): applied command

### DIFF
--- a/quick/wg.go
+++ b/quick/wg.go
@@ -109,11 +109,19 @@ func execSh(command string, iface string, logger zerolog.Logger, stdin ...string
 		cmd.Stdin = b
 	}
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Err(err).Msgf("failed to execute %s:\n%s", cmd.Args, out)
-		return err
+	if len(out) > 0 {
+		if err != nil {
+			logger.Err(err).Msgf("failed to execute %s:\n%s", cmd.Args, out)
+			return err
+		}
+		logger.Info().Msgf("executed %s:\n%s", cmd.Args, out)
+	} else {
+		if err != nil {
+			logger.Err(err).Msgf("failed to execute %s", cmd.Args)
+			return err
+		}
+		logger.Info().Msgf("executed %s", cmd.Args)
 	}
-	logger.Info().Msgf("executed %s:\n%s", cmd.Args, out)
 	return nil
 }
 


### PR DESCRIPTION
```shell
root@XG:/etc/wireguard# wb dn_gs_tz
12:43PM ERR failed to down interface error="Link not found" iface=dn_gs_tz
12:43PM INF link not found, creating iface=dn_gs_tz
12:43PM INF set device up iface=dn_gs_tz
12:43PM INF synced link iface=dn_gs_tz
12:43PM INF synced link iface=dn_gs_tz
12:43PM INF synced addresses iface=dn_gs_tz
12:43PM INF Table=off, skip route sync iface=dn_gs_tz
12:43PM INF Successfully synced device iface=dn_gs_tz
12:43PM INF executed [sh -ce /sbin/ip addr add dev dn_gs_tz 172.16.70.254/32 peer 172.16.45.254/32]:
 iface=dn_gs_tz
12:43PM INF applied post-up command iface=dn_gs_tz
12:43PM INF executed [sh -ce wg set dn_gs_tz fwmark 0x46]:
 iface=dn_gs_tz
12:43PM INF applied post-up command iface=dn_gs_tz
12:43PM INF bounce done
```