### PR TITLE
修复log.level=warning不生效的问题，并提升日志等级字符串的鲁棒性

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -3,9 +3,9 @@ package conf
 import (
 	_ "embed"
 	"os"
+	"strings"
 	"time"
 	
-	"strings"
 	"github.com/fsnotify/fsnotify"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"


### PR DESCRIPTION
Fixes #18 

