### PR TITLE
fix: recognize FwMark field off value

### DIFF
--- a/quick/config.go
+++ b/quick/config.go
@@ -416,6 +416,10 @@ func parseInterfaceLine(cfg *Config, lhs string, rhs string) error {
 	case "WgBin":
 		cfg.WgBin = rhs
 	case "FwMark":
+		if strings.ToLower(rhs) == "off" {
+			cfg.FirewallMark = nil
+			return nil
+		}
 		mark64, err := strconv.ParseInt(rhs, 0, 64)
 		if err != nil {
 			return err


### PR DESCRIPTION
根据 wg 的 [man](https://www.man7.org/linux/man-pages/man8/wg.8.html#CONFIGURATION_FILE_FORMAT)，FwMark 字段除了数字，也支持配置为 `off`。

>FwMark — a 32-bit fwmark for outgoing packets. If set to 0
>or "off", this option is disabled. May be specified in
>hexadecimal by prepending "0x". Optional.